### PR TITLE
Flush dirty buffer when querying an early stream

### DIFF
--- a/quantile.go
+++ b/quantile.go
@@ -138,7 +138,7 @@ func (est *Estimator) Add(value float64) {
 // Get finds a value within (quantile - tolerance) * n <= value <= (quantile + tolerance) * n
 // or 0 if no values have been observed.
 func (est *Estimator) Get(quantile float64) float64 {
-	if est.observations == 0 {
+	if est.observations == 0 && len(est.buffer) == 0 {
 		return 0
 	}
 

--- a/quantile_test.go
+++ b/quantile_test.go
@@ -115,3 +115,11 @@ func TestQueryEmptyStreamShouldNotPanic(t *testing.T) {
 		t.Fatalf("expected 0, got %f", val)
 	}
 }
+
+func TestQueryEarlyStreamWithDirtyBuffer(t *testing.T) {
+	est := New(Known(0.99, 0.0001))
+	est.Add(1)
+	if got, want := est.Get(0.99), 1.0; got != want {
+		t.Fatalf("got %f, want %f", got, want)
+	}
+}


### PR DESCRIPTION
Querying an early stream before its buffer had been flushed was erroneously
returning 0.

Fixes #3