### PR TITLE
Minimal fix for Go 1.18 compatibility

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,14 +1,13 @@
-package quantile_test
+package quantile
 
 import (
-	quantile "." // import fully qualified in your code
 	"fmt"
 	"time"
 )
 
-var rpcs *quantile.Estimator
+var rpcs *Estimator
 
-func observeSeconds(est *quantile.Estimator, begin time.Time) {
+func observeSeconds(est *Estimator, begin time.Time) {
 	est.Add(float64(time.Now().Sub(begin)) / float64(time.Second))
 }
 
@@ -22,7 +21,7 @@ func Work() {
 
 func ExampleEstimator() {
 	// We know we want to query the 95th and 99th, with the 95th a little less accurately.
-	rpcs = quantile.New(quantile.Known(0.95, 0.005), quantile.Known(0.99, 0.001))
+	rpcs = New(Known(0.95, 0.005), Known(0.99, 0.001))
 
 	Work()
 	Work()


### PR DESCRIPTION
Unfortunately it seems like Go 1.18 has removed the ability to do `import "."`
in non-`go.mod` projects.

A more full fix for this is probably to create a go.mod with the canonical
import path... but as that may also break imports that were pulling this
project from another path, I haven't done that in this commit.

Personally / the source of this problem for  me is that go.uber.org/yarpc
uses tchannel which uses this, which fails with:
```
go.uber.org/yarpc imports
	github.com/uber/tchannel-go tested by
	github.com/uber/tchannel-go.test imports
	github.com/streadway/quantile tested by
	github.com/streadway/quantile.test imports
	.: "." is relative, but relative import paths are not supported in module mode
```
